### PR TITLE
Net::OpenTimeout and Net::ReadTimeout

### DIFF
--- a/source/posts/2008-01-29-rescuing-net-http-exceptions.html.markdown.erb
+++ b/source/posts/2008-01-29-rescuing-net-http-exceptions.html.markdown.erb
@@ -12,7 +12,7 @@ Just for the love of google, here's what I've got for the "right way" of catchin
 begin
   response = Net::HTTP.post_form(...) # or any Net::HTTP call
 rescue Timeout::Error, Errno::EINVAL, Errno::ECONNRESET, EOFError,
-       Net::HTTPBadResponse, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
+       Net::HTTPBadResponse, Net::OpenTimeout, Net::ReadTimeout, Net::HTTPHeaderSyntaxError, Net::ProtocolError => e
   ...
 end
 ~~~


### PR DESCRIPTION
For Ruby 2.x
- Net::ReadTimeout
- Net::OpenTimeout

They refer `@read_timeout` and `@open_timeout` on HTTP. I like to set them to lower values to ensure the http call is not blocking for a longer period of time.
